### PR TITLE
Proposal: reverse geocoder

### DIFF
--- a/geocode/geocode.py
+++ b/geocode/geocode.py
@@ -14,6 +14,7 @@ import numpy as np
 import hashlib
 import json
 from .flags import flags
+from .reverse_geocoder import ReverseGeocoder
 
 
 logging.basicConfig(level=logging.INFO, format='%(asctime)s [%(levelname)-5.5s] [%(name)-12.12s]: %(message)s')
@@ -311,6 +312,9 @@ class Geocode():
     def get_arguments_hash(self):
         geocode_args = [str(self.min_population_cutoff), str(self.large_city_population_cutoff)] + self.location_types
         return hashlib.sha256(','.join(geocode_args).encode()).hexdigest()[:15]
+
+    def build_reverse_geocoder(self):
+        return ReverseGeocoder(self.geo_data)
 
     # private
 

--- a/geocode/reverse_geocoder.py
+++ b/geocode/reverse_geocoder.py
@@ -1,0 +1,18 @@
+import numpy as np
+from sklearn.neighbors import KDTree
+
+class ReverseGeocoder():
+
+    def __init__(self, geo_data):
+        self.geo_data = geo_data
+
+        coord_arr = np.asarray(list((d[3], d[4]) for d in self.geo_data))
+
+        self.tree = KDTree(coord_arr)
+
+    def nearest_geodata(self, lon, lat):
+        value = (lon, lat)
+
+        index = self.tree.query([value])[1][0][0]
+
+        return self.geo_data[index]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ pandas>=1
 tqdm
 flashtext
 joblib
+scikit-learn


### PR DESCRIPTION
I saw #2 and this is one of the few local geocoding libraries, so I had the need to implement a reverse geocoder based on it. I'm proposing a way to execute reverse geocoding from the `geo_data` variable inside `Geocode`.

Root idea is to fit a KDTree (imported from `scikit-learn`) on the longitudes and latitudes, so that a new latitude and longitude pair can be queried, in order to obtain the index of the nearest location.

An example of use of the branch:

```
from geocode.geocode import Geocode
gc = Geocode()
gc.load()

rgc = gc.build_reverse_geocoder()
rgc.nearest_geodata(11.20, 43.75)

# ['Scandicci', 'Scandicci', 'IT', 11.18794, 43.75423, '3166988', 'place', 44951]
```

basically a class `ReverseGeocoder` is returned by `Geocode` and that class holds the kdtree to query the nearest points.

I don't know if the PR fits your idea of the project.
In case also the way in which it's implemented or the function names could be modified. Docs could be added to this PR if it makes sense.

Let me know if it is of interest for you!